### PR TITLE
fix: made replaceTextWithNode more resilient to focus change

### DIFF
--- a/src/tagify.js
+++ b/src/tagify.js
@@ -1126,7 +1126,7 @@ Tagify.prototype = {
 
         strToReplace = strToReplace || this.state.tag.prefix + this.state.tag.value;
         var idx, nodeToReplace,
-            selection = window.getSelection(),
+            selection = this.state.selection || window.getSelection(),
             nodeAtCaret = selection.anchorNode,
             firstSplitOffset = this.state.tag.delimiters ? this.state.tag.delimiters.length : 0;
 


### PR DESCRIPTION
Current `replaceTextWithNode` logic assumes no one else has grabbed the focus away from tagify input.

That's often is not the case if external dropdown is involved. To make the logic more resilient, work with the saved selection on focus loss by default and use `window.getSelection()` as backup when no such saved selection is available.